### PR TITLE
Fix en intercambio de recursos secundario

### DIFF
--- a/app/models/RecursosModel.php
+++ b/app/models/RecursosModel.php
@@ -174,55 +174,55 @@
 			switch($idRaza){
 	        	case 1:
 		        	if($modo)
-		        		$cantidad=floor($cantidad*TAURIPRIMARIO/TAURISECUNDARIO);
+		        		$cantidad=$cantidad*TAURIPRIMARIO/TAURISECUNDARIO;
 		        	else
-		        		$cantidad=floor($cantidad*TAURISECUNDARIO/TAURIPRIMARIO);
+		        		$cantidad=$cantidad*TAURISECUNDARIO/TAURIPRIMARIO;
 		        	break;
 	        	case 2:
 		        	if($modo)
-		        		$cantidad=floor($cantidad*GOAULDPRIMARIO/GOAULDSECUNDARIO);
+		        		$cantidad=$cantidad*GOAULDPRIMARIO/GOAULDSECUNDARIO;
 		        	else
-		        		$cantidad=floor($cantidad*GOAULDSECUNDARIO/GOAULDPRIMARIO);
+		        		$cantidad=$cantidad*GOAULDSECUNDARIO/GOAULDPRIMARIO;
 		        	break;
 	        	case 3:
 		        	if($modo)
-		        		$cantidad=floor($cantidad*ASGARDPRIMARIO/ASGARDSECUNDARIO);
+		        		$cantidad=$cantidad*ASGARDPRIMARIO/ASGARDSECUNDARIO;
 		        	else
-		        		$cantidad=floor($cantidad*ASGARDSECUNDARIO/ASGARDPRIMARIO);
+		        		$cantidad=$cantidad*ASGARDSECUNDARIO/ASGARDPRIMARIO;
 		        	break;
 	        	case 4:
 		        	if($modo)
-		        		$cantidad=floor($cantidad*JAFFAPRIMARIO/JAFFASECUNDARIO);
+		        		$cantidad=$cantidad*JAFFAPRIMARIO/JAFFASECUNDARIO;
 		        	else
-		        		$cantidad=floor($cantidad*JAFFASECUNDARIO/JAFFAPRIMARIO);
+		        		$cantidad=$cantidad*JAFFASECUNDARIO/JAFFAPRIMARIO;
 	        		break;
 	        	case 5:
 		        	if($modo)
-		        		$cantidad=floor($cantidad*ATLANTISPRIMARIO/ATLANTISSECUNDARIO);
+		        		$cantidad=$cantidad*ATLANTISPRIMARIO/ATLANTISSECUNDARIO;
 		        	else
-		        		$cantidad=floor($cantidad*ATLANTISSECUNDARIO/ATLANTISPRIMARIO);
+		        		$cantidad=$cantidad*ATLANTISSECUNDARIO/ATLANTISPRIMARIO;
 		        	break;
 	        	case 6:
 		        	if($modo)
-		        		$cantidad=floor($cantidad*WRAITHPRIMARIO/WRAITHSECUNDARIO);
+		        		$cantidad=$cantidad*WRAITHPRIMARIO/WRAITHSECUNDARIO;
 		        	else
-		        		$cantidad=floor($cantidad*WRAITHSECUNDARIO/WRAITHPRIMARIO);
+		        		$cantidad=$cantidad*WRAITHSECUNDARIO/WRAITHPRIMARIO;
 		        	break;
 		        case 7:
 		        	if($modo)
-		        		$cantidad=floor($cantidad*REPLICANTESPRIMARIO/REPLICANTESSECUNDARIO);
+		        		$cantidad=$cantidad*REPLICANTESPRIMARIO/REPLICANTESSECUNDARIO;
 		        	else
-		        		$cantidad=floor($cantidad*REPLICANTESSECUNDARIO/REPLICANTESPRIMARIO);
+		        		$cantidad=$cantidad*REPLICANTESSECUNDARIO/REPLICANTESPRIMARIO;
 		        	break;
 	        	case 8:
 		        	if($modo)
-		        		$cantidad=floor($cantidad*ORIPRIMARIO/ORISECUNDARIO);
+		        		$cantidad=$cantidad*ORIPRIMARIO/ORISECUNDARIO;
 		        	else
-		        		$cantidad=floor($cantidad*ORISECUNDARIO/ORIPRIMARIO);
+		        		$cantidad=$cantidad*ORISECUNDARIO/ORIPRIMARIO;
 		        	break;
 	        }
 			//Aplicamos cargo por intercambiar
-			return intval($cantidad*0.9);
+			return intval(floor($cantidad*0.9));
 	        
 	    }
 	    

--- a/web/js/Recursos/info.js
+++ b/web/js/Recursos/info.js
@@ -64,51 +64,51 @@ function calcular(){
 	}
 	else if(idRaza==1){
 		if(modo==1)
-			cantidad=Math.floor(valor*3/8);
+			cantidad=valor*3/8;
 		else
-			cantidad=Math.floor(valor*8/3);
+			cantidad=valor*8/3;
 	}
 	else if(idRaza==2){
 		if(modo==1)
-			cantidad=Math.floor(valor*2/9);
+			cantidad=valor*2/9;
 		else
-			cantidad=Math.floor(valor*9/2);
+			cantidad=valor*9/2;
 	}
 	else if(idRaza==3){
 		if(modo==1)
-			cantidad=Math.floor(valor*10/1);
+			cantidad=valor*10/1;
 		else
-			cantidad=Math.floor(valor*1/10);
+			cantidad=valor*1/10;
 	}
 	else if(idRaza==4){
 		if(modo==1)
-			cantidad=Math.floor(valor*3/8);
+			cantidad=valor*3/8;
 		else
-			cantidad=Math.floor(valor*8/3);
+			cantidad=valor*8/3;
 	}
 	else if(idRaza==5){
 		if(modo==1)
-			cantidad=Math.floor(valor*3/8);
+			cantidad=valor*3/8;
 		else
-			cantidad=Math.floor(valor*8/3);
+			cantidad=valor*8/3;
 	}
 	else if(idRaza==6){
 		if(modo==1)
-			cantidad=Math.floor(valor*2/9);
+			cantidad=valor*2/9;
 		else
-			cantidad=Math.floor(valor*9/2);
+			cantidad=valor*9/2;
 	}
 	else if(idRaza==7){
 		if(modo==1)
-			cantidad=Math.floor(valor*1/10);
+			cantidad=valor*1/10;
 		else
-			cantidad=Math.floor(valor*10/1);
+			cantidad=valor*10/1;
 	}
 	else if(idRaza==8){
 		if(modo==1)
-			cantidad=Math.floor(valor*2/9);
+			cantidad=valor*2/9;
 		else
-			cantidad=Math.floor(valor*9/2);
+			cantidad=valor*9/2;
 	}
 	
 	//Aplicamos cargo por intercambio


### PR DESCRIPTION
He cambiado cómo se aplica el floor en el intercambio de recursos.

Cuando es del primario al secundario iba bien, por ejemplo, el recursos relación 1 = 10 se le hace un *0.9 y de 1 dan 9
Pero cuando se hace al revés `12/10 * 0.9 = 1.08` deberían dar 1 y estaban dando 0. Se estaba aplicando ->
 `12/10 = 1.2 --> floor --> 1 --> * 0.9 = 0.9 --> floor = 0`
He quitado el primer floor en el intercambio y solo se queda el último, quedando: 
`12 / 10 = 1.2 --> * 0.9 = 1.08 --> floor = 1`