### PR TITLE
Fix, marca mensajes como leídos

### DIFF
--- a/app/models/MensajesModel.php
+++ b/app/models/MensajesModel.php
@@ -114,10 +114,12 @@
 	    public function marcarLeidos($idJugador, $idMensajes, $leido)
 	    {
 	        
-	    	$this->db->query('UPDATE recibeMensaje SET leido=\''.$leido.'\'
+	    	$this->db->query('UPDATE recibeMensaje SET leido='.$leido.'
 	    					WHERE idMensaje IN (\''.implode('\',\'',$idMensajes).'\')
 	    						AND idJugador=\''.$idJugador.'\'');
 	    	return $this->db->errno==0;
+
+			
 	        
 	    }
 	


### PR DESCRIPTION
Se corrige la sentencia SQL porque el campo leído número y se le enviaba un carácter. 